### PR TITLE
Exclude obsolete zones from known IANA and Windows lists

### DIFF
--- a/src/TimeZoneConverter/TZConvert.cs
+++ b/src/TimeZoneConverter/TZConvert.cs
@@ -40,6 +40,16 @@ namespace TimeZoneConverter
             // Special case - not in any map.
             KnownIanaTimeZoneNames.Add("Antarctica/Troll");
 
+            // Remove zones from KnownIanaTimeZoneNames that have been removed from IANA data.
+            // (They should still map to Windows zones correctly.)
+            KnownIanaTimeZoneNames.Remove("Canada/East-Saskatchewan");   // Removed in 2017c
+            KnownIanaTimeZoneNames.Remove("US/Pacific-New");             // Removed in 2018a
+
+            // Remove zones from KnownWindowsTimeZoneIds that are marked obsolete in the Windows Registry.
+            // (They should still map to IANA zones correctly.)
+            KnownWindowsTimeZoneIds.Remove("Kamchatka Standard Time");
+            KnownWindowsTimeZoneIds.Remove("Mid-Atlantic Standard Time");
+
 #if !NETSTANDARD1_1
             SystemTimeZones = GetSystemTimeZones();
 #endif
@@ -325,23 +335,7 @@ namespace TimeZoneConverter
             if (IsWindows)
                 return TimeZoneInfo.GetSystemTimeZones().ToDictionary(x => x.Id, x => x, StringComparer.OrdinalIgnoreCase);
 
-            var zones = GetSystemTimeZonesLinux().ToDictionary(x => x.Id, x => x, StringComparer.OrdinalIgnoreCase);
-
-            // Include special case to resolve deleted link
-            if (!zones.ContainsKey("Canada/East-Saskatchewan"))
-            {
-                try
-                {
-                    var tzi = TimeZoneInfo.FindSystemTimeZoneById("Canada/Saskatchewan");
-                    zones.Add("Canada/East-Saskatchewan", tzi);
-                }
-                catch
-                {
-                    // ignored
-                }
-            }
-
-            return zones;
+            return GetSystemTimeZonesLinux().ToDictionary(x => x.Id, x => x, StringComparer.OrdinalIgnoreCase);
 #else
             return TimeZoneInfo.GetSystemTimeZones().ToDictionary(x => x.Id, x => x, StringComparer.OrdinalIgnoreCase);
 #endif

--- a/test/TimeZoneConverter.Tests/IanaToWindowsTests.cs
+++ b/test/TimeZoneConverter.Tests/IanaToWindowsTests.cs
@@ -102,5 +102,19 @@ namespace TimeZoneConverter.Tests
             string result = TZConvert.IanaToWindows("Europe/Skopje");
             Assert.Equal("Central European Standard Time", result);
         }
+
+        [Fact]
+        public void Can_Convert_East_Saskatchewan_To_Windows()
+        {
+            string result = TZConvert.IanaToWindows("Canada/East-Saskatchewan");
+            Assert.Equal("Canada Central Standard Time", result);
+        }
+
+        [Fact]
+        public void Can_Convert_Pacific_New_To_Windows()
+        {
+            string result = TZConvert.IanaToWindows("US/Pacific-New");
+            Assert.Equal("Pacific Standard Time", result);
+        }
     }
 }

--- a/test/TimeZoneConverter.Tests/KnownTimeZonesTests.cs
+++ b/test/TimeZoneConverter.Tests/KnownTimeZonesTests.cs
@@ -27,5 +27,29 @@ namespace TimeZoneConverter.Tests
         {
             Assert.Contains(TZConvert.KnownIanaTimeZoneNames, x => x == "Antarctica/Troll");
         }
+
+        [Fact]
+        public void Known_IANA_TimeZones_Excludes_East_Saskatchewan()
+        {
+            Assert.DoesNotContain(TZConvert.KnownIanaTimeZoneNames, x => x == "Canada/East-Saskatchewan");
+        }
+
+        [Fact]
+        public void Known_IANA_TimeZones_Excludes_Pacific_New()
+        {
+            Assert.DoesNotContain(TZConvert.KnownIanaTimeZoneNames, x => x == "US/Pacific-New");
+        }
+
+        [Fact]
+        public void Known_Windows_TimeZones_Excludes_Kamchatka()
+        {
+            Assert.DoesNotContain(TZConvert.KnownWindowsTimeZoneIds, x => x == "Kamchatka Standard Time");
+        }
+
+        [Fact]
+        public void Known_Windows_TimeZones_Excludes_Mid_Atlantic()
+        {
+            Assert.DoesNotContain(TZConvert.KnownWindowsTimeZoneIds, x => x == "Mid-Atlantic Standard Time");
+        }
     }
 }

--- a/test/TimeZoneConverter.Tests/WindowsToIanaTests.cs
+++ b/test/TimeZoneConverter.Tests/WindowsToIanaTests.cs
@@ -107,5 +107,19 @@ namespace TimeZoneConverter.Tests
             string result = TZConvert.WindowsToIana("Yukon Standard Time");
             Assert.Equal("America/Whitehorse", result);
         }
+
+        [Fact]
+        public void Can_Convert_Kamchatka_Standard_Time_To_IANA()
+        {
+            string result = TZConvert.WindowsToIana("Kamchatka Standard Time");
+            Assert.Equal("Asia/Kamchatka", result);
+        }
+
+        [Fact]
+        public void Can_Convert_Mid_Atlantic_Standard_Time_To_IANA()
+        {
+            string result = TZConvert.WindowsToIana("Mid-Atlantic Standard Time");
+            Assert.Equal("Etc/GMT+2", result);
+        }
     }
 }


### PR DESCRIPTION
This removes `Canada/East-Saskatchewan` and `US/Pacific-New` from `KnownIanaTimeZoneNames`.  They will still work in conversion.

It also removes `Kamchatka Standard Time` and `Mid-Atlantic Standard Time` from `KnownWindowsTimeZoneIds`.  They will still work in conversion.

Fixes #89